### PR TITLE
更新链接正则

### DIFF
--- a/Action.php
+++ b/Action.php
@@ -38,10 +38,10 @@ class Meting_Action extends Typecho_Widget implements Widget_Interface_Do {
             }
             elseif(strpos($url,'xiami.com')!==false){
                 $server='xiami';
-                if(preg_match('/collect\/([^\.]*)/i',$url,$id))list($id,$type)=array($id[1],'playlist');
-                elseif(preg_match('/album\/([^\.]*)/i',$url,$id))list($id,$type)=array($id[1],'album');
-                elseif(preg_match('/song\/([^\.]*)/i',$url,$id))list($id,$type)=array($id[1],'song');
-                elseif(preg_match('/artist\/([^\.]*)/i',$url,$id))list($id,$type)=array($id[1],'artist');
+                if(preg_match('/collect\/(\w+)/i',$url,$id))list($id,$type)=array($id[1],'playlist');
+                elseif(preg_match('/album\/(\w+)/i',$url,$id))list($id,$type)=array($id[1],'album');
+                elseif(preg_match('/[\/.]\w+\/[songdem]+\/(\w+)/i',$url,$id))list($id,$type)=array($id[1],'song');
+                elseif(preg_match('/artist\/(\w+)/i',$url,$id))list($id,$type)=array($id[1],'artist');
                 if(!preg_match('/^\d*$/i',$id,$t)){
                     $data=self::curl($url);
                     preg_match('/'.$type.'\/(\d+)/i',$data,$id);
@@ -51,8 +51,9 @@ class Meting_Action extends Typecho_Widget implements Widget_Interface_Do {
             elseif(strpos($url,'kugou.com')!==false){
                 $server='kugou';
                 if(preg_match('/special\/single\/(\d+)/i',$url,$id))list($id,$type)=array($id[1],'playlist');
-                elseif(preg_match('/album\/single\/(\d+)/i',$url,$id))list($id,$type)=array($id[1],'album');
-                elseif(preg_match('/singer\/home\/(\d+)/i',$url,$id))list($id,$type)=array($id[1],'artist');
+                elseif(preg_match('/song\/#hash\=(\w+)/i',$url,$id))list($id,$type)=array($id[1],'song');
+                elseif(preg_match('/album\/[single\/]*(\d+)/i',$url,$id))list($id,$type)=array($id[1],'album');
+                elseif(preg_match('/singer\/[home\/]*(\d+)/i',$url,$id))list($id,$type)=array($id[1],'artist');
             }
             elseif(strpos($url,'baidu.com')!==false){
                 $server='baidu';


### PR DESCRIPTION
这个播放器很强大也很好用，更新了一下正则匹配，支持更多链接的匹配。
主要更新以下内容：
- 虾米不会将后缀 ?spm 匹配进去
- 虾米单曲链接支持 demo 匹配
- 酷狗单曲支持 hash 匹配
- 酷狗支持新链接匹配，新链接没有 single 和 home